### PR TITLE
Isolate the HTTP flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.1
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.25.0
 	github.com/stretchr/testify v1.7.0

--- a/models.go
+++ b/models.go
@@ -14,6 +14,7 @@ type Message struct {
 	Retqueue   string `json:"ret"`
 	Schema     string `json:"shm"`
 	Epoch      int64  `json:"now"`
+	Proxy      bool   `json:"pxy"`
 	Err        string `json:"err"`
 }
 

--- a/server.go
+++ b/server.go
@@ -168,7 +168,7 @@ func (a *App) handleFromReplyForward(ctx context.Context, msg Message) error {
 
 func (a *App) handleFromReply(ctx context.Context, msg Message) error {
 
-	if msg.TwinDst[0] == a.twin {
+	if msg.TwinDst[0] == a.twin || msg.Proxy {
 		return a.handleFromReplyForMe(ctx, msg)
 
 	} else if msg.TwinSrc == a.twin {
@@ -308,7 +308,9 @@ func (a *App) run(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	msg.TwinSrc = a.twin
+	if !msg.Proxy {
+		log.Warn().Err(err).Msg("The Message received over http request and proxy field false")
+	}
 	msg.Retqueue = uuid.New().String()
 
 	err := a.backend.PushToLocal(r.Context(), msg)


### PR DESCRIPTION
- Add `Proxy` field to the Message object to Isolate the HTTP flow
