### PR TITLE
v0.1.7

### DIFF
--- a/cmds/msgbusd/main.go
+++ b/cmds/msgbusd/main.go
@@ -21,6 +21,7 @@ type flags struct {
 	substrate string
 	debug     string
 	redis     string
+	workers   int
 }
 
 func (f *flags) Valid() error {
@@ -36,7 +37,7 @@ func main() {
 	flag.StringVar(&f.substrate, "substrate", "wss://tfchain.dev.grid.tf/ws", "substrate url")
 	flag.StringVar(&f.debug, "log-level", "info", "log level [debug|info|warn|error|fatal|panic]")
 	flag.StringVar(&f.redis, "redis", "127.0.0.1:6379", "redis url")
-
+	flag.IntVar(&f.workers, "workers", 1000, "workers is number of active channels that communicate with the backend")
 	flag.Parse()
 
 	if err := f.Valid(); err != nil {
@@ -52,7 +53,7 @@ func main() {
 }
 
 func app(f flags) error {
-	s, err := rmb.NewServer(f.substrate, f.redis, f.twin)
+	s, err := rmb.NewServer(f.substrate, f.redis, f.twin, f.workers)
 	if err != nil {
 		return errors.Wrap(err, "failed to create server")
 	}

--- a/models.go
+++ b/models.go
@@ -27,4 +27,5 @@ type App struct {
 	twin     int
 	resolver TwinResolver
 	server   *http.Server
+	workers  int
 }


### PR DESCRIPTION
* set 10 sec timeout for the requests

* handle messages in parallel

* Use limted NO. of workers instead of unlimted logic

* Increas the number of workers to be 1000

* make workers configurable

* stop all workers in case of shutdown

* Update server.go

Co-authored-by: Muhamad Azmy <muhamad@incubaid.com>

* get all twins in the same time

* Revert "get all twins in the same time"

This reverts commit ee23f53d79447e91de66caad2fd51c499269490f.

Co-authored-by: Waleed <waleed.hammam@gmail.com>
Co-authored-by: Muhamad Azmy <muhamad@incubaid.com>